### PR TITLE
Add a context option to show text near a reported location

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,10 +117,19 @@ function parse(files, options) {
       label = message.fatal ? 'error' : 'warning';
 
       if (options.context) {
-        var line = String(file).split('\n')[message.location.start.line - 1];
+        var lines = String(file).split('\n');
+        var line = lines[message.location.start.line - 1];
         var startIndex = message.location.start.column - 1 - options.context;
         var endIndex = message.location.end.column + options.context;
-        var context = line.slice(startIndex > 0 ? startIndex : 0, endIndex < line.length ? endIndex : line.length);
+        var contextStart = startIndex > 0 ? startIndex : 0;
+        var contextEnd = endIndex < line.length ? endIndex : line.length;
+        var context;
+        if (message.location.start.line < message.location.end.line) {
+          var endLine = lines[message.location.end.line - 1];
+          context = line.slice(contextStart, line.length) + '...' + endLine.slice(0, contextEnd);
+        } else {
+          context = line.slice(contextStart, contextEnd);
+        }
         rows.push({
           type: 'context',
           context: context

--- a/index.js
+++ b/index.js
@@ -116,6 +116,17 @@ function parse(files, options) {
 
       label = message.fatal ? 'error' : 'warning';
 
+      if (options.context) {
+        var line = String(file).split('\n')[message.location.start.line - 1];
+        var startIndex = message.location.start.column - 1 - options.context;
+        var endIndex = message.location.end.column + options.context;
+        var context = line.slice(startIndex > 0 ? startIndex : 0, endIndex < line.length ? endIndex : line.length);
+        rows.push({
+          type: 'context',
+          context: context
+        });
+      }
+
       rows.push({
         location: loc,
         label: label,
@@ -174,6 +185,8 @@ function compile(map, one, options) {
       if (line) {
         lines.push(line);
       }
+    } else if (row.type === 'context') {
+      lines.push('"...' + row.context + '..."');
     } else {
       lines.push(trim.right([
         '',

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,9 @@ Generate a stylish report from the given files.
         — Label to use for files without file-path.
         If one file and no `defaultName` is given, no name
         will show up in the report.
+    *   `context` (`integer`, default: `0`)
+        — Print out the specified number of characters before
+        and after the reported location above each message.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -329,6 +329,54 @@ test('vfile-reporter', function (t) {
 
   t.equal(reporter(vfile({path: 'a.js'}), {color: false}), 'a.js: no issues found', 'should support `color: false`');
 
+  file = vfile('Hello this is a file with some issues');
+  file.message('Warning!', {
+    start: {line: 1, column: 17},
+    end: {line: 1, column: 20}
+  });
+
+  t.equal(chalk.stripColor(reporter(file, {context: 6})),
+    [
+      '"... is a file with ..."',
+      '  1:17-1:20  warning  Warning!',
+      '',
+      '⚠ 1 warning'
+    ].join('\n'),
+    'should support context'
+  );
+
+  file = vfile('Hello this is a file with some issues');
+  file.message('Warning!', {
+    start: {line: 1, column: 2},
+    end: {line: 1, column: 8}
+  });
+
+  t.equal(chalk.stripColor(reporter(file, {context: 3})),
+    [
+      '"...Hello this ..."',
+      '  1:2-1:8  warning  Warning!',
+      '',
+      '⚠ 1 warning'
+    ].join('\n'),
+    'should support context near the start of a line'
+  );
+
+  file = vfile('Hello this is a file with some issues');
+  file.message('Warning!', {
+    start: {line: 1, column: 27},
+    end: {line: 1, column: 30}
+  });
+
+  t.equal(chalk.stripColor(reporter(file, {context: 15})),
+    [
+      '"...is a file with some issues..."',
+      '  1:27-1:30  warning  Warning!',
+      '',
+      '⚠ 1 warning'
+    ].join('\n'),
+    'should support context near the end of a line'
+  );
+
   t.end();
 });
 

--- a/test.js
+++ b/test.js
@@ -377,6 +377,25 @@ test('vfile-reporter', function (t) {
     'should support context near the end of a line'
   );
 
+  file = vfile([
+    'Hello this is a file with some issues',
+    'especially this issue that wraps the line'
+  ].join('\n'));
+  file.message('Warning!', {
+    start: {line: 1, column: 27},
+    end: {line: 2, column: 3}
+  });
+
+  t.equal(chalk.stripColor(reporter(file, {context: 2})),
+    [
+      '"...h some issues...espec..."',
+      '  1:27-2:3  warning  Warning!',
+      '',
+      '⚠ 1 warning'
+    ].join('\n'),
+    'should support context for a message that spans multiple lines'
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
This PR adds a  [grep-like](https://www.gnu.org/savannah-checkouts/gnu/grep/manual/grep.html#Context-Line-Control) `context` option, which will log a specified number of characters before and after a message location so that each issue is easier to find.