### PR TITLE
Add `verbose` option to `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,11 @@ or `Error`.
 
 ##### `options`
 
+##### `options.verbose`
+
+Output long form descriptions of messages, if applicable (`boolean`, default:
+`false`).
+
 ###### `options.quiet`
 
 Do not output anything for a file which has no warnings or errors (`boolean`,


### PR DESCRIPTION
This adds a little bit of text to the README to mention `options.verbose`. The [README for `vfile-message`](https://github.com/vfile/vfile-message) mentions that `vfile-reporter` supports this, so I figured that the documentation for the package itself ought to mention this too.

Thanks for considering this change!